### PR TITLE
feat: CloudSQL設定追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
       - "**.md"
 env:
   TF_VAR_GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+  TF_VAR_MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
 
 jobs:
   terraform:

--- a/cloud_sql.tf
+++ b/cloud_sql.tf
@@ -14,3 +14,10 @@ resource "google_sql_database" "cookingbomb_database" {
   charset   = "utf8mb4"
   collation = "utf8mb4_bin"
 }
+
+resource "google_sql_user" "cookingbomb_root" {
+  name     = "root"
+  instance = google_sql_database_instance.cookingbomb.name
+  host     = "%"
+  password = var.MYSQL_ROOT_PASSWORD
+}

--- a/cloud_sql.tf
+++ b/cloud_sql.tf
@@ -1,4 +1,4 @@
-resource "google_sql_database_instance" "cooking_bomb" {
+resource "google_sql_database_instance" "cookingbomb" {
   name             = "cookingbomb-mysql"
   database_version = "MYSQL_8_0"
   region           = "us-west1"

--- a/cloud_sql.tf
+++ b/cloud_sql.tf
@@ -7,3 +7,10 @@ resource "google_sql_database_instance" "cookingbomb" {
     tier = "db-f1-micro"
   }
 }
+
+resource "google_sql_database" "cookingbomb_database" {
+  name      = "cooking_bomb"
+  instance  = google_sql_database_instance.cookingbomb.name
+  charset   = "utf8mb4"
+  collation = "utf8mb4_bin"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,2 +1,5 @@
 variable "GOOGLE_CREDENTIALS" {
 }
+
+variable "MYSQL_ROOT_PASSWORD" {
+}


### PR DESCRIPTION
## Issues
resolve #2 

## About
CloudSQL設定追加

## Details
- インスタンス作成

一番安い`us-west1/db-f1-micro`

- データベース作成

localと同じく`cooking_bomb`

- mysqlルートユーザー作成

passwordはgithubSecretの中に。


## Remarks
他にこんな設定・リソースが必要そうなら言って欲しい！